### PR TITLE
chore: hide docs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@ import { Navbar } from "@/components/Navbar";
 import { Hero } from "@/components/Hero";
 import { Features } from "@/components/Features";
 import { Installation } from "@/components/Installation";
-import { Documentation } from "@/components/Documentation";
 import { Examples } from "@/components/Examples";
 import { Community } from "@/components/Community";
 import { GitHub } from "@/components/GitHub";
@@ -15,7 +14,6 @@ export default function Home() {
       <Hero />
       <Features />
       <Installation />
-      <Documentation />
       <Examples />
       <Community />
       <GitHub />

--- a/components/Examples.tsx
+++ b/components/Examples.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState } from "react";
-import Link from "next/link";
 
 const Examples = () => {
   const [copiedExample, setCopiedExample] = useState<number | null>(null);
@@ -115,28 +114,6 @@ apee-i request GET https://api.example.com/data \\
               </button>
             </div>
           ))}
-        </div>
-
-        <div className="mt-12 text-center">
-          <Link
-            href="#documentation"
-            className="inline-flex items-center text-cyan-400 hover:text-cyan-300 transition-colors"
-          >
-            View More Examples in Documentation
-            <svg
-              className="w-5 h-5 ml-2"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M17 8l4 4m0 0l-4 4m4-4H3"
-              />
-            </svg>
-          </Link>
         </div>
       </div>
     </section>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -31,7 +31,7 @@ const Footer = () => {
     },
   ];
 
-  const quickLinks = ["Home", "Features", "Documentation", "Examples"];
+  const quickLinks = ["Home", "Features", "Examples"];
   const communityLinks = ["GitHub", "Discord", "Twitter", "Blog"];
   const footerLinks = ["Privacy Policy", "Terms of Service", "License"];
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -22,11 +22,6 @@ const Hero = () => {
                   Get Started
                 </p>
               </Link>
-              <Link href="#documentation">
-                <p className="px-8 py-3 bg-neutral-700 hover:bg-neutral-600 rounded-lg text-center font-semibold transition-all duration-300">
-                  Documentation
-                </p>
-              </Link>
             </div>
           </div>
 

--- a/components/Installation.tsx
+++ b/components/Installation.tsx
@@ -13,7 +13,6 @@ const Installation = () => {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
           <div className="space-y-8 animate__animated animate__fadeInLeft">
-
             <div className="space-y-4">
               <h3 className="text-2xl font-semibold text-cyan-400">
                 Installation Steps
@@ -28,9 +27,7 @@ const Installation = () => {
 
                 <li>Install via NPM:</li>
                 <div className="bg-neutral-800 p-4 rounded-lg">
-                  <code className="text-cyan-400">
-					npm install -g apee-i
-                  </code>
+                  <code className="text-cyan-400">npm install -g apee-i</code>
                 </div>
 
                 <li>Verify installation:</li>
@@ -72,7 +69,7 @@ const Installation = () => {
               </div>
             </div>
 
-            <div className="mt-8 p-4 bg-cyan-900/30 rounded-lg border border-cyan-500/20">
+            <div className="mt-8 p-4 bg-cyan-900/30 rounded-lg border border-cyan-500/20 w-fit">
               <p className="text-sm text-cyan-400">
                 <svg
                   className="inline-block w-5 h-5 mr-2"
@@ -87,14 +84,7 @@ const Installation = () => {
                     d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                   />
                 </svg>
-                Need help? Check out our{" "}
-                <Link
-                  href="#documentation"
-                  className="underline hover:text-cyan-300"
-                >
-                  documentation
-                </Link>{" "}
-                or join our{" "}
+                Need help? Join our{" "}
                 <Link
                   href="#community"
                   className="underline hover:text-cyan-300"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -35,11 +35,6 @@ const Navbar = () => {
                   Installation
                 </p>
               </Link>
-              <Link href="#documentation">
-                <p className="hover:bg-neutral-700 px-3 py-2 rounded-md text-sm font-medium">
-                  Docs
-                </p>
-              </Link>
               <Link href="#examples">
                 <p className="hover:bg-neutral-700 px-3 py-2 rounded-md text-sm font-medium">
                   Examples
@@ -109,14 +104,6 @@ const Navbar = () => {
               className="block hover:bg-neutral-700 px-3 py-2 rounded-md text-base font-medium"
             >
               Installation
-            </p>
-          </Link>
-          <Link href="#documentation">
-            <p
-              onClick={closeMobileMenu}
-              className="block hover:bg-neutral-700 px-3 py-2 rounded-md text-base font-medium"
-            >
-              Docs
             </p>
           </Link>
           <Link href="#examples">


### PR DESCRIPTION
This PR hides documentation page and option in navbar. Its an ad-hoc solution until we roll out the documentation site. Temporarily resolves #6 and #7.